### PR TITLE
chore: point every Discord link at the anolilab server

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,6 @@ The anolilab résumé is open-sourced software licensed under the [MIT license][
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge
 [prs-welcome]: https://github.com/anolilab/resume/blob/main/.github/CONTRIBUTING.md
 [chat-badge]: https://img.shields.io/discord/902465130518949899.svg?style=for-the-badge
-[chat]: https://discord.com/invite/TtFJY8xkFK
+[chat]: https://discord.com/invite/eajEZvk2PG
 [typescript-badge]: https://img.shields.io/badge/Typescript-294E80.svg?style=for-the-badge&logo=typescript
 [typescript-url]: https://www.typescriptlang.org/


### PR DESCRIPTION
Three different Discord invites were in circulation across these repositories:

| Invite | Server |
| --- | --- |
| `TtFJY8xkFK` | **Visulima** |
| `J8GxgQ7Xv5` | **does not resolve** — the invite is dead |
| `eajEZvk2PG` | **anolilab** |

I checked each one against Discord's invite API rather than inferring from where they appeared; `J8GxgQ7Xv5` returns nothing, so anyone clicking that chat badge reached an expired invite.

This file now points at `eajEZvk2PG`, the anolilab server. Companion pull requests do the same in visulima/visulima (54 files, including the package template) and anolilab/semantic-release (6 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Discord chat badge link in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->