### PR TITLE
ci: declare explicit permissions on the shared workflow callers

### DIFF
--- a/.github/workflows/allo-allo.yaml
+++ b/.github/workflows/allo-allo.yaml
@@ -11,6 +11,11 @@ on: # yamllint disable-line rule:truthy
             - "opened"
             - "closed"
 
+permissions:
+    contents: "read" # to read the repository
+    issues: "write" # for the shared workflow to comment on and label issues
+    pull-requests: "write" # for the shared workflow to comment on and label pull requests
+
 jobs:
     allo-allo:
         uses: "anolilab/workflows/.github/workflows/allo-allo.yml@13fa35fefde7f2ad64dbaa108f6421ae3062d711" # v18.0.4 # main

--- a/.github/workflows/cache-clear.yml
+++ b/.github/workflows/cache-clear.yml
@@ -5,6 +5,10 @@ on: # yamllint disable-line rule:truthy
         types:
             - "closed"
 
+permissions:
+    actions: "write" # to delete caches for the merged branch
+    contents: "read" # to read the repository
+
 jobs:
     cleanup-branch-cache:
         uses: "anolilab/workflows/.github/workflows/cleanup-branch-cache.yaml@13fa35fefde7f2ad64dbaa108f6421ae3062d711" # v18.0.4 # main

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -4,6 +4,11 @@ on: # yamllint disable-line rule:truthy
     schedule:
         - cron: "0 0 * * *"
 
+permissions:
+    contents: "read" # to read the repository
+    issues: "write" # for the shared workflow to comment on and label issues
+    pull-requests: "write" # for the shared workflow to comment on and label pull requests
+
 jobs:
     stale-issues:
         uses: "anolilab/workflows/.github/workflows/stale-issues.yml@13fa35fefde7f2ad64dbaa108f6421ae3062d711" # v18.0.4 # main


### PR DESCRIPTION
These workflows call reusable workflows in `anolilab/workflows` and declare no `permissions` of their own, so the token they receive is whatever the repository default happens to be — currently **write**.

That default is the only thing keeping this repository from running Actions with a read-only token. A caller cannot grant a reusable workflow more than it holds, so each block below is exactly what the callee declares, read from the callee rather than guessed:

- `allo-allo.yaml` — contents: read, issues: write, pull-requests: write
- `cache-clear.yml` — actions: write, contents: read
- `stale-issues.yml` — contents: read, issues: write, pull-requests: write

Once this merges the repository default can drop to read-only with nothing losing access it was using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation permissions to support issue and pull request management.
  * Enabled automated cache cleanup workflows to remove cached data when required.
  * Maintained read access to repository contents for workflow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->